### PR TITLE
Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+updates:
+  - directory: /
+    package-ecosystem: docker-compose
+    schedule:
+      interval: daily
+      time: 00:00
+    target-branch: dependabot
+version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,13 @@
 updates:
   - directory: /
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     package-ecosystem: docker-compose
     schedule:
       interval: daily
       time: "00:00"
     target-branch: dependabot
+
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,5 @@ updates:
     schedule:
       interval: daily
       time: "00:00"
-    target-branch: dependabot
 
 version: 2

--- a/README.md
+++ b/README.md
@@ -103,22 +103,6 @@ The deployment is driven by a compose file that utilizes several environment var
   SSL_LABS_IPV6_CIDR=2600:c02:1020:4202::/64
   ```
 
-- **STATIC_WEB_SERVER_VERSION**  
-  *Description:* The version of the static web server image used by the **[Static Web Server](https://static-web-server.net/configuration/config-file/)**.  
-  *Default:* `2.36.0`  
-  *Example:*  
-  ```env
-  STATIC_WEB_SERVER_VERSION=2.36.0
-  ```
-
-- **TRAEFIK_VERSION**  
-  *Description:* The version of the **[Traefik](https://doc.traefik.io/traefik/)** image to deploy.  
-  *Default:* `3.3.3`  
-  *Example:*  
-  ```env
-  TRAEFIK_VERSION=3.3.3
-  ```
-
 ## Usage
 
 1. **Create a `.env` file**  
@@ -131,8 +115,6 @@ The deployment is driven by a compose file that utilizes several environment var
    HOSTNAME=proxy.example.com
    SSL_LABS_IPV4_CIDR=64.41.200.0/24
    SSL_LABS_IPV6_CIDR=2600:c02:1020:4202::/64
-   STATIC_WEB_SERVER_VERSION=2.36.0
-   TRAEFIK_VERSION=3.3.3
    ```
 
 2. **Deploy with Compose**  

--- a/compose.yml
+++ b/compose.yml
@@ -202,7 +202,7 @@ services:
     healthcheck:
       # @BUG: For some reason `traefik healthcheck` does not pass health checks with manual routing
       test: ["CMD", "wget", "--spider", "-q", "https://${HOSTNAME:?}/traefik/ping"]
-    image: traefik:3.3.4
+    image: traefik:3.3.3
     ports:
       - 80:80
       - 443:443

--- a/compose.yml
+++ b/compose.yml
@@ -177,7 +177,7 @@ services:
           memory: 8M
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1/health"]
-    image: joseluisq/static-web-server:${STATIC_WEB_SERVER_VERSION:-2.36.0}-alpine
+    image: joseluisq/static-web-server:2.36.0-alpine
     labels:
       - traefik.enable=true
       - traefik.http.routers.securityFile.rule=Path("/.well-known/security.txt")
@@ -202,7 +202,7 @@ services:
     healthcheck:
       # @BUG: For some reason `traefik healthcheck` does not pass health checks with manual routing
       test: ["CMD", "wget", "--spider", "-q", "https://${HOSTNAME:?}/traefik/ping"]
-    image: traefik:${TRAEFIK_VERSION:-3.3.3}
+    image: traefik:3.3.3
     ports:
       - 80:80
       - 443:443

--- a/compose.yml
+++ b/compose.yml
@@ -202,7 +202,7 @@ services:
     healthcheck:
       # @BUG: For some reason `traefik healthcheck` does not pass health checks with manual routing
       test: ["CMD", "wget", "--spider", "-q", "https://${HOSTNAME:?}/traefik/ping"]
-    image: traefik:3.3.3
+    image: traefik:3.3.4
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
- Disable Dependabot target branch
- Ignore major versions
- Remove env vars for docker images as they're incompatible with Dependabot